### PR TITLE
Fix dead link of sotm-us 2013 conference recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,4 @@ For now, let me explain by offering the abstract from my presentation at the 201
 
 This github repository includes some of the scripts I am using to perform this quantitative analysis. At this point they may not be complete or functional, but in time I hope to post all my code here.
 
-For more information, see this [blog post](http://mappingmashups.net/2013/05/25/introducing-map-gardening/), or watch [this video](http://vimeopro.com/openstreetmapus/state-of-the-map-us-2013/video/68097490) from the [2013 State of the Map US Conference](http://stateofthemap.us/)
+For more information, see this [blog post](http://mappingmashups.net/2013/05/25/introducing-map-gardening/), or watch [this video](https://vimeo.com/68097490) from the [2013 State of the Map US Conference](http://stateofthemap.us/)


### PR DESCRIPTION
The recording of the sotm-us talk is now available under a slightly different URL.